### PR TITLE
Repairing the mysterious neck loading problem

### DIFF
--- a/Body/NeckCad.groovy
+++ b/Body/NeckCad.groovy
@@ -10,7 +10,7 @@ class Neck implements ICadGenerator {
 	ArrayList<CSG> makeNeck() {
 		ArrayList<CSG> fullHead = new ArrayList<CSG>()
 		CSG channel = generateBody()//andrew was here
-
+		
 		int xSize = 70
 		int ySize = (channel.getMaxY() - channel.getMinY())
 		int zSize = 37
@@ -42,7 +42,8 @@ class Neck implements ICadGenerator {
 		//fullHead.add(channel)
 		//fullHead.add(servo)
 		fullHead.add(base)
-		return [fullHead.collect{it.toXMin()}]
+		
+		return fullHead.collect{it.toXMin()}
 	}
 
 	@Override

--- a/FullDog/Dog.xml
+++ b/FullDog/Dog.xml
@@ -1,11 +1,11 @@
 <root>
 <mobilebase>
 	<cadEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>FullDog/laserCutCad.groovy</file>
 	</cadEngine>
 	<driveEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>walkingGait.groovy</file>
 	</driveEngine>
 
@@ -14,7 +14,7 @@
 
 <name>BackLeft</name>
 	<cadEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -209,7 +209,7 @@
 
 <name>FrontRight</name>
 	<cadEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -404,7 +404,7 @@
 
 <name>FrontLeft</name>
 	<cadEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -599,7 +599,7 @@
 
 <name>BackRight</name>
 	<cadEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -794,7 +794,7 @@
 
 <name>Neck</name>
 	<cadEngine>
-		<git>https://github.com/madhephaestus/Bulldog.git</git>
+		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
 		<file>Body/NeckCad.groovy</file>
 	</cadEngine>
 	<kinematics>

--- a/FullDog/Dog.xml
+++ b/FullDog/Dog.xml
@@ -989,7 +989,7 @@
 
 <name>Tail</name>
 	<cadEngine>
-		<git>https://gist.github.com/bcb4760a449190206170.git</git>
+		<git>https://github.com/madhephaestus/carl-the-hexapod.git</git>
 		<file>ThreeDPrintCad.groovy</file>
 	</cadEngine>
 	<kinematics>

--- a/FullDog/Dog.xml
+++ b/FullDog/Dog.xml
@@ -1,11 +1,11 @@
 <root>
 <mobilebase>
 	<cadEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>FullDog/laserCutCad.groovy</file>
 	</cadEngine>
 	<driveEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>walkingGait.groovy</file>
 	</driveEngine>
 
@@ -14,7 +14,7 @@
 
 <name>BackLeft</name>
 	<cadEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -209,7 +209,7 @@
 
 <name>FrontRight</name>
 	<cadEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -404,7 +404,7 @@
 
 <name>FrontLeft</name>
 	<cadEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -599,7 +599,7 @@
 
 <name>BackRight</name>
 	<cadEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>LegLinks/feetCad.groovy</file>
 	</cadEngine>
 	<kinematics>
@@ -794,7 +794,7 @@
 
 <name>Neck</name>
 	<cadEngine>
-		<git>https://github.com/DotSlash-CTF/Bulldog.git</git>
+		<git>https://github.com/madhephaestus/Bulldog.git</git>
 		<file>Body/NeckCad.groovy</file>
 	</cadEngine>
 	<kinematics>


### PR DESCRIPTION

ArrayList<ArrayList<CSG>> not ArrayList<CSG> This is passed upstream 
and ignored by Groovy's loose typechecking. The java layer finally throws a typecheck \
error when trying to render the objects.